### PR TITLE
feat(auth): OAuth2 소셜 로그인 및 JWT/refreshToken 인증 구현

### DIFF
--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/TokenController.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/TokenController.java
@@ -1,0 +1,116 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web;
+
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.RefreshTokenRequest;
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.TokenResponse;
+import com.nolahyong.nolahyong_backend.adapter.out.token.RefreshTokenEntity;
+import com.nolahyong.nolahyong_backend.application.service.RefreshTokenService;
+import com.nolahyong.nolahyong_backend.application.service.TokenService;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshTokens(
+            @Valid @RequestBody RefreshTokenRequest request,
+            HttpServletResponse response
+    ) {
+        // Refresh Token 검증
+        if (!tokenService.validateToken(request.getRefreshToken())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("Invalid refresh token");
+        }
+
+        // 사용자 정보 추출
+        UUID userId = tokenService.getUserIdFromToken(request.getRefreshToken());
+        Optional<User> userOpt = userRepository.findById(userId);
+        if (userOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("User not found");
+        }
+
+        // 저장소에서 Refresh Token 확인
+        Optional<RefreshTokenEntity> tokenEntity = refreshTokenService.findByRefreshToken(
+                request.getRefreshToken()
+        );
+        if (tokenEntity.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("Refresh token not found");
+        }
+
+        // 새로운 Access Token 발급
+        User user = userOpt.get();
+        String newAccessToken = tokenService.generateAccessToken(user);
+
+        // 토큰 로테이션: 필요시 새 Refresh Token 발급
+        String newRefreshToken = null;
+        if (shouldRotateRefreshToken(tokenEntity.get())) {
+            newRefreshToken = tokenService.generateRefreshToken(user);
+            refreshTokenService.saveRefreshToken(
+                    user.getUserId(),
+                    newRefreshToken,
+                    tokenEntity.get().getDeviceFingerprint()
+            );
+        }
+
+        // 응답 설정
+        setSecureCookies(response, newAccessToken, newRefreshToken);
+        return ResponseEntity.ok(new TokenResponse(newAccessToken, newRefreshToken));
+    }
+
+    private boolean shouldRotateRefreshToken(RefreshTokenEntity tokenEntity) {
+        Instant now = Instant.now();
+        Instant threeDaysLater = now.plus(3, ChronoUnit.DAYS);
+
+        // LocalDateTime -> Instant 변환
+        Instant expiresAtInstant = tokenEntity.getExpiresAt()
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+
+        return expiresAtInstant.isBefore(threeDaysLater);
+    }
+
+    private void setSecureCookies(HttpServletResponse response,
+                                  String accessToken, String refreshToken) {
+        if (accessToken != null) {
+            Cookie cookie = new Cookie("access_token", accessToken);
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
+            cookie.setPath("/");
+            cookie.setMaxAge((int) tokenService.getAccessTokenValidity());
+            response.addCookie(cookie);
+        }
+
+        if (refreshToken != null) {
+            Cookie cookie = new Cookie("refresh_token", refreshToken);
+            cookie.setHttpOnly(true);
+            cookie.setSecure(true);
+            cookie.setPath("/api/auth/refresh");
+            cookie.setMaxAge((int) tokenService.getRefreshTokenValidity());
+            response.addCookie(cookie);
+        }
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/UserController.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/UserController.java
@@ -1,0 +1,21 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web;
+
+import com.nolahyong.nolahyong_backend.application.dto.UserInfo;
+import com.nolahyong.nolahyong_backend.security.CustomUserPrincipal;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+    @GetMapping("/me")
+    public ResponseEntity<UserInfo> getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserPrincipal principal = (CustomUserPrincipal) authentication.getPrincipal();
+        User user = principal.getUser();
+        return ResponseEntity.ok(UserInfo.from(user));
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Data
+public class RefreshTokenRequest {
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/TokenResponse.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/token/RefreshTokenEntity.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/token/RefreshTokenEntity.java
@@ -1,0 +1,36 @@
+package com.nolahyong.nolahyong_backend.adapter.out.token;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_tokens")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "token_id")
+    private UUID tokenId;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "refresh_token_encrypted", nullable = false, columnDefinition = "TEXT")
+    private String refreshToken;
+
+    @Column(name = "device_fingerprint")
+    private String deviceFingerprint;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/token/RefreshTokenRepository.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/token/RefreshTokenRepository.java
@@ -1,0 +1,30 @@
+package com.nolahyong.nolahyong_backend.adapter.out.token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, UUID> {
+
+    Optional<RefreshTokenEntity> findByRefreshToken(String refreshToken);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RefreshTokenEntity r WHERE r.userId = :userId AND r.deviceFingerprint = :deviceFingerprint")
+    void deleteByUserIdAndDeviceFingerprint(@Param("userId") UUID userId, @Param("deviceFingerprint") String deviceFingerprint);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RefreshTokenEntity r WHERE r.expiresAt < :now")
+    void deleteExpiredTokens(@Param("now") LocalDateTime now);
+
+    boolean existsByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/user/LoadUserPortAdapter.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/user/LoadUserPortAdapter.java
@@ -1,0 +1,27 @@
+package com.nolahyong.nolahyong_backend.adapter.out.user;
+
+import com.nolahyong.nolahyong_backend.application.port.out.LoadUserPort;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.model.SnsProvider;
+import com.nolahyong.nolahyong_backend.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LoadUserPortAdapter implements LoadUserPort {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Optional<User> findByProviderAndProviderId(SnsProvider provider, String providerId) {
+        return userRepository.findByProviderAndProviderId(provider, providerId);
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/dto/SnsLoginRequest.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/dto/SnsLoginRequest.java
@@ -1,0 +1,11 @@
+package com.nolahyong.nolahyong_backend.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SnsLoginRequest {
+    private String authorizationCode;
+    private String redirectUri;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/port/out/LoadUserPort.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/port/out/LoadUserPort.java
@@ -1,0 +1,11 @@
+package com.nolahyong.nolahyong_backend.application.port.out;
+
+import com.nolahyong.nolahyong_backend.domain.model.SnsProvider;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+
+import java.util.Optional;
+
+public interface LoadUserPort {
+    Optional<User> findByProviderAndProviderId(SnsProvider provider, String providerId);
+    User save(User user);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/port/out/TokenPort.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/port/out/TokenPort.java
@@ -1,0 +1,11 @@
+package com.nolahyong.nolahyong_backend.application.port.out;
+
+import com.nolahyong.nolahyong_backend.domain.model.User;
+
+import java.util.UUID;
+
+public interface TokenPort {
+    String generateAccessToken(User user);
+    String generateRefreshToken(User user);
+    void saveRefreshToken(UUID userId, String refreshToken, String deviceFingerprint);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/RefreshTokenService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/RefreshTokenService.java
@@ -1,0 +1,45 @@
+package com.nolahyong.nolahyong_backend.application.service;
+
+import com.nolahyong.nolahyong_backend.adapter.out.token.RefreshTokenEntity;
+import com.nolahyong.nolahyong_backend.adapter.out.token.RefreshTokenRepository;
+import lombok.*;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final long refreshTokenValidity = 604800L; // 7일
+
+    public void saveRefreshToken(UUID userId, String refreshToken, String deviceFingerprint) {
+        refreshTokenRepository.deleteByUserIdAndDeviceFingerprint(userId, deviceFingerprint);
+        RefreshTokenEntity tokenEntity = RefreshTokenEntity.builder()
+                .userId(userId)
+                .refreshToken(refreshToken)
+                .deviceFingerprint(deviceFingerprint)
+                .expiresAt(
+                        LocalDateTime.ofInstant(
+                                Instant.now().plusSeconds(refreshTokenValidity),
+                                ZoneId.systemDefault()
+                        )
+                )
+                .build();
+        refreshTokenRepository.save(tokenEntity);
+    }
+
+    public Optional<RefreshTokenEntity> findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken);
+    }
+
+    public void deleteRefreshToken(UUID userId, String deviceFingerprint) {
+        refreshTokenRepository.deleteByUserIdAndDeviceFingerprint(userId, deviceFingerprint);
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/TokenService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/TokenService.java
@@ -1,0 +1,83 @@
+package com.nolahyong.nolahyong_backend.application.service;
+
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class TokenService {
+
+    private final SecretKey secretKey;
+    @Getter
+    private final long accessTokenValidity;
+    @Getter
+    private final long refreshTokenValidity;
+
+    public TokenService(
+            @Value("${jwt.secret}") String jwtSecret,
+            @Value("${jwt.access-token-validity}") long accessTokenValidity,
+            @Value("${jwt.refresh-token-validity}") long refreshTokenValidity
+    ) {
+        this.accessTokenValidity = accessTokenValidity;
+        this.refreshTokenValidity = refreshTokenValidity;
+        this.secretKey = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(User user) {
+        return buildToken(user, accessTokenValidity);
+    }
+
+    public String generateRefreshToken(User user) {
+        return buildToken(user, refreshTokenValidity);
+    }
+
+    private String buildToken(User user, long validity) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + validity * 1000);    // 추후 사용 예정?
+
+        return Jwts.builder()
+                .subject(user.getUserId().toString())
+                .claim("email", user.getEmail())
+                .claim("nickname", user.getNickname())
+                .claim("provider", user.getProvider().name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenValidity * 1000))
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return true;
+        } catch (Exception e) {
+            log.error("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public UUID getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return UUID.fromString(claims.getSubject());
+    }
+
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/config/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/config/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,46 @@
+package com.nolahyong.nolahyong_backend.config;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+
+    public CustomAuthorizationRequestResolver(ClientRegistrationRepository repo,
+                                              String authorizationRequestBaseUri) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+                repo, authorizationRequestBaseUri);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest req = defaultResolver.resolve(request);
+        return customizeAuthorizationRequest(req);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request,
+                                              String clientRegistrationId) {
+        OAuth2AuthorizationRequest req = defaultResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(req);
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest req) {
+        if (req == null) return null;
+
+        // PKCE 파라미터 추가
+        Map<String, Object> additionalParameters = new HashMap<>(req.getAdditionalParameters());
+        additionalParameters.put("code_challenge_method", "S256");
+
+        return OAuth2AuthorizationRequest.from(req)
+                .additionalParameters(additionalParameters)
+                .build();
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/config/CustomOAuth2UserService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/config/CustomOAuth2UserService.java
@@ -1,0 +1,78 @@
+package com.nolahyong.nolahyong_backend.config;
+
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.model.AccountStatus;
+import com.nolahyong.nolahyong_backend.domain.model.SnsProvider;
+import com.nolahyong.nolahyong_backend.application.port.out.LoadUserPort;
+import com.nolahyong.nolahyong_backend.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final LoadUserPort loadUserPort;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        try {
+            return processOAuth2User(userRequest, oAuth2User);
+        } catch (Exception ex) {
+            OAuth2Error error = new OAuth2Error(
+                    "oauth2_login_failed",
+                    "OAuth2 로그인 처리 중 오류 발생: " + ex.getMessage(),
+                    null
+            );
+            throw new OAuth2AuthenticationException(error, ex);
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        String providerString = userRequest.getClientRegistration().getRegistrationId();
+        SnsProvider provider = SnsProvider.valueOf(providerString.toUpperCase());
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        String providerId = oAuth2User.getName();
+        String email = (String) attributes.get("email");
+        String nickname = (String) attributes.getOrDefault("name", attributes.get("nickname"));
+        String profileImageUrl = (String) attributes.getOrDefault("picture", attributes.get("profile_image_url"));
+
+        Optional<User> userOptional = loadUserPort.findByProviderAndProviderId(provider, providerId);
+
+        User user = userOptional
+                .map(existingUser -> updateExistingUser(existingUser, nickname, profileImageUrl))
+                .orElseGet(() -> registerNewUser(provider, providerId, email, nickname, profileImageUrl));
+
+        // CustomUserPrincipal로 래핑하여 반환
+        return new CustomUserPrincipal(user, attributes);
+    }
+
+    private User registerNewUser(SnsProvider provider, String providerId, String email, String nickname, String profileImageUrl) {
+        User user = User.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .email(email)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
+        return loadUserPort.save(user);
+    }
+
+    private User updateExistingUser(User existingUser, String nickname, String profileImageUrl) {
+        existingUser.setNickname(nickname);
+        existingUser.setProfileImageUrl(profileImageUrl);
+        return loadUserPort.save(existingUser);
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/config/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/config/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,88 @@
+package com.nolahyong.nolahyong_backend.config;
+
+import com.nolahyong.nolahyong_backend.application.service.RefreshTokenService;
+import com.nolahyong.nolahyong_backend.application.service.TokenService;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.security.CustomUserPrincipal;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+
+        CustomUserPrincipal userPrincipal = (CustomUserPrincipal) authentication.getPrincipal();
+        User user = userPrincipal.getUser();
+
+        // 토큰 생성
+        String accessToken = tokenService.generateAccessToken(user);
+        String refreshToken = tokenService.generateRefreshToken(user);
+
+        // 디바이스 지문 생성 (User-Agent + IP 기반 해시)
+        String deviceFingerprint = generateDeviceFingerprint(request);
+
+        // 리프레시 토큰 저장 (기존 토큰 삭제 후 새 토큰 저장)
+        refreshTokenService.saveRefreshToken(user.getUserId(), refreshToken, deviceFingerprint);
+
+        // 안전한 쿠키 설정
+        setSecureCookies(response, accessToken, refreshToken);
+
+        // 모바일 앱을 위한 JSON 응답
+        sendMobileResponse(response, accessToken, refreshToken);
+    }
+
+    private String generateDeviceFingerprint(HttpServletRequest request) {
+        String userAgent = request.getHeader("User-Agent");
+        String ipAddress = request.getRemoteAddr();
+        return DigestUtils.sha256Hex(userAgent + ipAddress);
+    }
+
+    private void setSecureCookies(HttpServletResponse response,
+                                  String accessToken, String refreshToken) {
+        // 액세스 토큰 쿠키 (HTTP Only, Secure)
+        Cookie accessTokenCookie = new Cookie("access_token", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setMaxAge((int) tokenService.getAccessTokenValidity());
+        response.addCookie(accessTokenCookie);
+
+        // 리프레시 토큰 쿠키 (HTTP Only, Secure)
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/api/auth/refresh");
+        refreshTokenCookie.setMaxAge((int) tokenService.getRefreshTokenValidity());
+        response.addCookie(refreshTokenCookie);
+    }
+
+    private void sendMobileResponse(HttpServletResponse response,
+                                    String accessToken, String refreshToken) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(
+                String.format("{\"access_token\":\"%s\",\"refresh_token\":\"%s\"}",
+                        accessToken, refreshToken)
+        );
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/config/SecurityConfig.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.nolahyong.nolahyong_backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    private final OAuth2AuthenticationSuccessHandler successHandler;
+
+    public SecurityConfig(OAuth2AuthenticationSuccessHandler successHandler) {
+        this.successHandler = successHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           ClientRegistrationRepository clientRegistrationRepository) throws Exception {
+        http
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**",
+                                "/api/auth/refresh",
+                                "/error",
+                                "/",
+                                "/index.html",
+                                "/favicon.ico"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(successHandler)
+                        .authorizationEndpoint(authorization -> authorization
+                                .authorizationRequestResolver(
+                                        new CustomAuthorizationRequestResolver(
+                                                clientRegistrationRepository, "/oauth2/authorization"))
+                        )
+                )
+                .requiresChannel(channel -> channel
+                        .anyRequest().requiresSecure() // HTTPS 강제 적용
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/AccountStatus.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/AccountStatus.java
@@ -1,0 +1,5 @@
+package com.nolahyong.nolahyong_backend.domain.model;
+
+public enum AccountStatus {
+    ACTIVE, INACTIVE, SUSPENDED
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/SnsProvider.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/SnsProvider.java
@@ -1,0 +1,7 @@
+package com.nolahyong.nolahyong_backend.domain.model;
+
+public enum SnsProvider {
+    GOOGLE
+    , KAKAO
+//    , NAVER
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
@@ -1,0 +1,35 @@
+package com.nolahyong.nolahyong_backend.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    private SnsProvider provider;
+
+    private String providerId;
+
+    @Setter
+    private String email;
+    @Setter
+    private String nickname;
+    @Setter
+    private String profileImageUrl;
+
+    // 7. AccountStatus 필드 추가
+    @Enumerated(EnumType.STRING)
+    private AccountStatus accountStatus;
+
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/repository/UserRepository.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.nolahyong.nolahyong_backend.domain.repository;
+
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.model.SnsProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByProviderAndProviderId(SnsProvider provider, String providerId);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/security/CustomUserPrincipal.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/security/CustomUserPrincipal.java
@@ -1,0 +1,70 @@
+package com.nolahyong.nolahyong_backend.security;
+
+import com.nolahyong.nolahyong_backend.domain.model.AccountStatus;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class CustomUserPrincipal implements OAuth2User, UserDetails {
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public CustomUserPrincipal(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getName() {
+        return user.getUserId().toString();
+    }
+
+    // UserDetails 메서드 구현
+    @Override
+    public String getPassword() {
+        return null; // 소셜 로그인은 패스워드 없음
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return user.getAccountStatus() == AccountStatus.ACTIVE;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,55 @@
 spring:
   application:
     name: nolahyong-backend
+
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password: ""
+    url: jdbc:postgresql://${DB_IP}/yongin_tour
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            scope: profile,email
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            authorization-grant-type: ${AUTHORIZATION-GRANT-TYPE}
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            scope: profile_nickname, account_email
+            client-name: Kakao
+#          naver:
+#            client-id: your-naver-client-id
+#            client-secret: your-naver-client-secret
+#            authorization-grant-type: authorization_code
+#            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+#            scope: name, email, profile_image
+#            client-name: Naver
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+#          naver:
+#            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+#            token-uri: https://nid.naver.com/oauth2.0/token
+#            user-info-uri: https://openapi.naver.com/v1/nid/me
+#            user-name-attribute: response
+
+jwt:
+  secret: ${SECRET}
+  access-token-validity: 3600  # 1시간 (초)
+  refresh-token-validity: 604800  # 7일 (초)


### PR DESCRIPTION
- SNS 로그인을 위해 CustomOAuth2UserService 및 OAuth2AuthenticationSuccessHandler 추가
- 토큰서비스 구현, JWT용 리프레시토큰서비스 및 리프레시토큰 발행/검증
- 인증 엔드포인트에 토큰 컨트롤러 및 관련 DTO 추가
- 사용자, 계정 상태, SNS 제공자 도메인 모델 통합
- OAuth2 및 토큰 기반 인증을 위한 SecurityConfig 구성