### PR TITLE
feat: 마이페이지 프로필 조회 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
@@ -1,13 +1,12 @@
 package com.nolahyong.nolahyong_backend.adapter.in.web;
 
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
-import com.nolahyong.nolahyong_backend.adapter.in.web.dto.UpdateProfileRequest;
-import com.nolahyong.nolahyong_backend.application.service.MyPageService;
-import jakarta.validation.Valid;
+import com.nolahyong.nolahyong_backend.application.port.in.MyPageUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -16,13 +15,21 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MyPageController {
 
-    private final MyPageService myPageService; // ★ 핵심: 내부의 MyPageUseCase 포트에 의존
+    private final MyPageUseCase myPageUseCase;
 
-
-    @GetMapping
+    @GetMapping("/profile")
     public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal(expression = "id") UUID userId) {
-        return ResponseEntity.ok(myPageService.getMyPage(userId));
+        return ResponseEntity.ok(myPageUseCase.getMyPage(userId));
     }
 
-
+    @PutMapping("/profile")
+    public ResponseEntity<Void> updateProfile(
+            @AuthenticationPrincipal(expression = "id") UUID userId,
+            @RequestParam("nickname") String nickname,
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage,
+            @RequestParam(value = "removeImage", defaultValue = "false") boolean removeImage
+    ) {
+        myPageUseCase.updateProfile(userId, nickname, profileImage, removeImage);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
@@ -1,7 +1,9 @@
 package com.nolahyong.nolahyong_backend.adapter.in.web;
 
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
-import com.nolahyong.nolahyong_backend.application.service.MyPageUseCase;
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.UpdateProfileRequest;
+import com.nolahyong.nolahyong_backend.application.service.MyPageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,12 +16,13 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MyPageController {
 
-    private final MyPageUseCase myPageUseCase; // ★ 핵심: 내부의 MyPageUseCase 포트에 의존
+    private final MyPageService myPageService; // ★ 핵심: 내부의 MyPageUseCase 포트에 의존
 
 
     @GetMapping
     public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal(expression = "id") UUID userId) {
-        return ResponseEntity.ok(myPageUseCase.getMyPage(userId));
+        return ResponseEntity.ok(myPageService.getMyPage(userId));
     }
+
 
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
@@ -1,6 +1,8 @@
 package com.nolahyong.nolahyong_backend.adapter.in.web;
 
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.CategoryResponse;
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.UpdateCategoriesRequest;
 import com.nolahyong.nolahyong_backend.application.port.in.MyPageUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -30,6 +33,19 @@ public class MyPageController {
             @RequestParam(value = "removeImage", defaultValue = "false") boolean removeImage
     ) {
         myPageUseCase.updateProfile(userId, nickname, profileImage, removeImage);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/categories")
+    public ResponseEntity<List<CategoryResponse>> getUserCategories(@AuthenticationPrincipal(expression = "id") UUID userId) {
+        return ResponseEntity.ok(myPageUseCase.getSelectedCategories(userId));
+    }
+
+    @PutMapping("/categories")
+    public ResponseEntity<Void> updateUserCategories(
+            @AuthenticationPrincipal(expression = "id") UUID userId,
+            @RequestBody UpdateCategoriesRequest request) {
+        myPageUseCase.updateSelectedCategories(userId, request.categoryCodes());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/MyPageController.java
@@ -1,0 +1,25 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web;
+
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+import com.nolahyong.nolahyong_backend.application.service.MyPageUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageUseCase myPageUseCase; // ★ 핵심: 내부의 MyPageUseCase 포트에 의존
+
+
+    @GetMapping
+    public ResponseEntity<MyPageResponse> getMyPage(@AuthenticationPrincipal(expression = "id") UUID userId) {
+        return ResponseEntity.ok(myPageUseCase.getMyPage(userId));
+    }
+
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/CategoryResponse.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/CategoryResponse.java
@@ -1,0 +1,4 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web.dto;
+
+public record CategoryResponse(String code, String name) {
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/MyPageResponse.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/MyPageResponse.java
@@ -1,0 +1,11 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyPageResponse {
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/MyPageResponse.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/MyPageResponse.java
@@ -1,11 +1,10 @@
 package com.nolahyong.nolahyong_backend.adapter.in.web.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class MyPageResponse {
-    private String nickname;
-    private String profileImageUrl;
+/**
+ * 마이페이지 조회 응답 DTO
+ */
+public record MyPageResponse(
+        String nickname,
+        String profileImageUrl
+) {
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/UpdateCategoriesRequest.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/in/web/dto/UpdateCategoriesRequest.java
@@ -1,0 +1,5 @@
+package com.nolahyong.nolahyong_backend.adapter.in.web.dto;
+
+import java.util.List;
+
+public record UpdateCategoriesRequest(List<String> categoryCodes) {}

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/image/StorageService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/image/StorageService.java
@@ -7,7 +7,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 
 @Slf4j

--- a/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/image/StorageService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/adapter/out/image/StorageService.java
@@ -1,0 +1,57 @@
+package com.nolahyong.nolahyong_backend.adapter.out.image;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StorageService {
+
+    @Value("${custom.image.upload-path}")
+    private String uploadDir;
+
+    public String store(UUID userId, MultipartFile file) {
+        try {
+            // 디렉토리가 없으면 생성
+            Path uploadPath = Paths.get(uploadDir);
+            if (!Files.exists(uploadPath)) {
+                Files.createDirectories(uploadPath);
+            }
+
+            // 원본 파일명 확보
+            String originalFilename = Paths.get(file.getOriginalFilename()).getFileName().toString();
+
+            // 저장될 파일명 구성
+            String filename = userId + "_" + UUID.randomUUID() + "_" + originalFilename;
+
+            // 저장 경로
+            Path targetPath = uploadPath.resolve(filename).normalize();
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            // 프론트에서 접근 가능한 URL 경로 반환
+            return "/images/" + filename;
+
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store file", e);
+        }
+    }
+
+    public void delete(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) return;
+        try {
+            String filename = Paths.get(imageUrl).getFileName().toString();
+            Path targetPath = Paths.get(uploadDir).resolve(filename);
+            Files.deleteIfExists(targetPath);
+        } catch (IOException e) {
+            log.warn("이미지 삭제 실패: {}", imageUrl, e);
+        }
+    }
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/port/in/MyPageUseCase.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/port/in/MyPageUseCase.java
@@ -1,0 +1,9 @@
+package com.nolahyong.nolahyong_backend.application.port.in;
+
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+
+import java.util.UUID;
+
+public interface MyPageUseCase {
+    MyPageResponse getMyPage(UUID userId);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/port/in/MyPageUseCase.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/port/in/MyPageUseCase.java
@@ -1,9 +1,12 @@
 package com.nolahyong.nolahyong_backend.application.port.in;
 
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
 public interface MyPageUseCase {
     MyPageResponse getMyPage(UUID userId);
+    void updateProfile(UUID userId, String nickname, MultipartFile profileImage, boolean removeImage);
 }
+

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/port/in/MyPageUseCase.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/port/in/MyPageUseCase.java
@@ -1,12 +1,19 @@
 package com.nolahyong.nolahyong_backend.application.port.in;
 
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.CategoryResponse;
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MyPageUseCase {
     MyPageResponse getMyPage(UUID userId);
+
     void updateProfile(UUID userId, String nickname, MultipartFile profileImage, boolean removeImage);
+
+    List<CategoryResponse> getSelectedCategories(UUID userId);
+
+    void updateSelectedCategories(UUID userId, List<String> categoryCodes);
 }
 

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
@@ -1,6 +1,7 @@
 package com.nolahyong.nolahyong_backend.application.service;
 
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+import com.nolahyong.nolahyong_backend.application.port.in.MyPageUseCase;
 import com.nolahyong.nolahyong_backend.domain.model.User;
 import com.nolahyong.nolahyong_backend.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class MyPageUseCase {
+public class MyPageService implements MyPageUseCase {
 
     private final UserRepository userRepository;
 

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
@@ -1,15 +1,21 @@
 package com.nolahyong.nolahyong_backend.application.service;
 
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.CategoryResponse;
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
 import com.nolahyong.nolahyong_backend.adapter.out.image.StorageService;
 import com.nolahyong.nolahyong_backend.application.port.in.MyPageUseCase;
+import com.nolahyong.nolahyong_backend.domain.model.Category;
 import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.model.UserCategory;
+import com.nolahyong.nolahyong_backend.domain.repository.CategoryRepository;
+import com.nolahyong.nolahyong_backend.domain.repository.UserCategoryRepository;
 import com.nolahyong.nolahyong_backend.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -18,24 +24,21 @@ public class MyPageService implements MyPageUseCase {
 
     private final UserRepository userRepository;
     private final StorageService storageService;
+    private final UserCategoryRepository userCategoryRepository;
+    private final CategoryRepository categoryRepository;
 
     @Override
     @Transactional(readOnly = true)
     public MyPageResponse getMyPage(UUID userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        return new MyPageResponse(
-                user.getNickname(),
-                user.getProfileImageUrl()
-        );
+        return new MyPageResponse(user.getNickname(), user.getProfileImageUrl());
     }
 
     @Override
     @Transactional
     public void updateProfile(UUID userId, String nickname, MultipartFile profileImage, boolean removeImage) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
 
         user.updateNickname(nickname);
 
@@ -52,6 +55,27 @@ public class MyPageService implements MyPageUseCase {
             }
             String imageUrl = storageService.store(userId, profileImage);
             user.updateProfileImage(imageUrl);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> getSelectedCategories(UUID userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        return userCategoryRepository.findByUser(user).stream().map(uc -> new CategoryResponse(uc.getCategory().getCode(), uc.getCategory().getNameKo())).toList();
+    }
+
+    @Override
+    @Transactional
+    public void updateSelectedCategories(UUID userId, List<String> categoryCodes) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        userCategoryRepository.deleteByUser(user);
+
+        List<Category> categories = categoryRepository.findByCodeIn(categoryCodes);
+        for (Category category : categories) {
+            userCategoryRepository.save(new UserCategory(user, category));
         }
     }
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
@@ -1,12 +1,14 @@
 package com.nolahyong.nolahyong_backend.application.service;
 
 import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+import com.nolahyong.nolahyong_backend.adapter.out.image.StorageService;
 import com.nolahyong.nolahyong_backend.application.port.in.MyPageUseCase;
 import com.nolahyong.nolahyong_backend.domain.model.User;
 import com.nolahyong.nolahyong_backend.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -15,18 +17,41 @@ import java.util.UUID;
 public class MyPageService implements MyPageUseCase {
 
     private final UserRepository userRepository;
+    private final StorageService storageService;
 
+    @Override
     @Transactional(readOnly = true)
     public MyPageResponse getMyPage(UUID userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
         return new MyPageResponse(
                 user.getNickname(),
                 user.getProfileImageUrl()
         );
     }
 
-    // 앞으로 추가될 메서드
-    // public void updateProfile(...);
-    // public List<String> getSelectedCategories(UUID userId);
+    @Override
+    @Transactional
+    public void updateProfile(UUID userId, String nickname, MultipartFile profileImage, boolean removeImage) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        user.updateNickname(nickname);
+
+        if (removeImage) {
+            String oldUrl = user.getProfileImageUrl();
+            if (oldUrl != null && !oldUrl.isBlank()) {
+                storageService.delete(oldUrl);
+            }
+            user.removeProfileImage();
+        } else if (profileImage != null && !profileImage.isEmpty()) {
+            String oldUrl = user.getProfileImageUrl();
+            if (oldUrl != null && !oldUrl.isBlank()) {
+                storageService.delete(oldUrl);
+            }
+            String imageUrl = storageService.store(userId, profileImage);
+            user.updateProfileImage(imageUrl);
+        }
+    }
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageService.java
@@ -42,19 +42,19 @@ public class MyPageService implements MyPageUseCase {
 
         user.updateNickname(nickname);
 
-        if (removeImage) {
-            String oldUrl = user.getProfileImageUrl();
-            if (oldUrl != null && !oldUrl.isBlank()) {
-                storageService.delete(oldUrl);
+        boolean hasOldImage = user.getProfileImageUrl() != null && !user.getProfileImageUrl().isBlank();
+
+        if (removeImage || (profileImage != null && !profileImage.isEmpty())) {
+            if (hasOldImage) {
+                storageService.delete(user.getProfileImageUrl());
             }
+        }
+
+        if (removeImage) {
             user.removeProfileImage();
         } else if (profileImage != null && !profileImage.isEmpty()) {
-            String oldUrl = user.getProfileImageUrl();
-            if (oldUrl != null && !oldUrl.isBlank()) {
-                storageService.delete(oldUrl);
-            }
-            String imageUrl = storageService.store(userId, profileImage);
-            user.updateProfileImage(imageUrl);
+            String newUrl = storageService.store(userId, profileImage);
+            user.updateProfileImage(newUrl);
         }
     }
 

--- a/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageUseCase.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/application/service/MyPageUseCase.java
@@ -1,0 +1,31 @@
+package com.nolahyong.nolahyong_backend.application.service;
+
+import com.nolahyong.nolahyong_backend.adapter.in.web.dto.MyPageResponse;
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageUseCase {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public MyPageResponse getMyPage(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return new MyPageResponse(
+                user.getNickname(),
+                user.getProfileImageUrl()
+        );
+    }
+
+    // 앞으로 추가될 메서드
+    // public void updateProfile(...);
+    // public List<String> getSelectedCategories(UUID userId);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/config/WebConfig.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/config/WebConfig.java
@@ -1,11 +1,18 @@
 package com.nolahyong.nolahyong_backend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${custom.image.upload-path}")
+    private String uploadDir;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -16,5 +23,12 @@ public class WebConfig implements WebMvcConfigurer {
                 .exposedHeaders("Authorization")
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String fullPath = Paths.get(uploadDir).toAbsolutePath().toUri().toString();
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations(fullPath);
     }
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/Category.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/Category.java
@@ -1,0 +1,31 @@
+package com.nolahyong.nolahyong_backend.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @Column(name = "category_code", length = 50)
+    private String code;
+
+    private String groupCode;
+
+    private String nameEn;
+
+    @Column(nullable = false)
+    private String nameKo;
+
+    private Integer sortOrder;
+
+}
+

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
@@ -49,4 +49,16 @@ public class User {
     public boolean isOnboarded() {
         return Boolean.TRUE.equals(profileCompleted);
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl; // null 가능
+    }
+
+    public void removeProfileImage() {
+        this.profileImageUrl = null;
+    }
 }

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
@@ -34,7 +34,10 @@ public class User {
     private String providerId;
 
     @Column(name = "profile_image")
-    private String profileImage; // 프로필 이미지 URL
+    private String profileImage; // 프로필 이미지
+
+    @Column(name = "profile_image_url;")
+    private String profileImageUrl; // 프로필 이미지 URL
 
     @Column(name = "profile_completed")
     private Boolean profileCompleted; // 온보딩 완료 여부

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/User.java
@@ -1,7 +1,7 @@
 package com.nolahyong.nolahyong_backend.domain.model;
 
-import com.nolahyong.nolahyong_backend.domain.model.enums.Provider;
 import com.nolahyong.nolahyong_backend.domain.model.enums.AccountStatus;
+import com.nolahyong.nolahyong_backend.domain.model.enums.Provider;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -36,7 +36,7 @@ public class User {
     @Column(name = "profile_image")
     private String profileImage; // 프로필 이미지
 
-    @Column(name = "profile_image_url;")
+    @Column(name = "profile_image_url")
     private String profileImageUrl; // 프로필 이미지 URL
 
     @Column(name = "profile_completed")

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/UserCategory.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/UserCategory.java
@@ -1,0 +1,26 @@
+package com.nolahyong.nolahyong_backend.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_categories")
+@IdClass(UserCategoryId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserCategory {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_code", referencedColumnName = "category_code")
+    private Category category;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/model/UserCategoryId.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/model/UserCategoryId.java
@@ -1,0 +1,16 @@
+package com.nolahyong.nolahyong_backend.domain.model;
+
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class UserCategoryId implements Serializable {
+    private UUID user;
+    private String category;
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.nolahyong.nolahyong_backend.domain.repository;
+
+import com.nolahyong.nolahyong_backend.domain.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, String> {
+    List<Category> findByCodeIn(List<String> codes);
+}

--- a/src/main/java/com/nolahyong/nolahyong_backend/domain/repository/UserCategoryRepository.java
+++ b/src/main/java/com/nolahyong/nolahyong_backend/domain/repository/UserCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.nolahyong.nolahyong_backend.domain.repository;
+
+import com.nolahyong.nolahyong_backend.domain.model.User;
+import com.nolahyong.nolahyong_backend.domain.model.UserCategory;
+import com.nolahyong.nolahyong_backend.domain.model.UserCategoryId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserCategoryRepository extends JpaRepository<UserCategory, UserCategoryId> {
+    List<UserCategory> findByUser(User user);
+
+    void deleteByUser(User user);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,3 +80,7 @@ springdoc:
 refresh:
   token:
     encryption-key: ${ENCRYPTION_KEY}
+
+custom:
+  image:
+    upload-path: ./uploads/profile


### PR DESCRIPTION
## 주요 변경사항

- 마이페이지 프로필 조회 API 구현 (`GET /api/user/mypage/profile`)
- 마이페이지 프로필 수정 API 구현 (`PUT /api/user/mypage/profile`)
  - 닉네임 수정
  - 프로필 이미지 업로드
  - 기존 이미지 삭제 처리 (removeImage 플래그)

- StorageService를 통해 서버 로컬에 이미지 저장
- 정적 리소스 핸들러 설정 (`/images/**` → `uploads/profile` 디렉토리)

## 테스트

- Postman으로 multipart/form-data 요청 테스트 완료
- 로컬 환경에서 이미지 저장 및 조회 정상 동작 확인
